### PR TITLE
Replace get_event_loop with single methods in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,16 @@ import pytest
 
 @pytest.fixture(scope="session")
 def event_loop():
-    """Force the pytest-asyncio loop to be the main one."""
-    loop = asyncio.get_event_loop()
+    """
+    Force the pytest-asyncio loop to be the main one.
+    If there is no running event loop, create one and
+    set as the current one.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     yield loop
 
 


### PR DESCRIPTION
Removes [the warning](https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop) in Python 3.10 caused by `get_event_loop` when  a current loop is not present. See also [this discussion](https://github.com/pytest-dev/pytest-asyncio/issues/212)

![tests_warning](https://user-images.githubusercontent.com/1734279/175658893-f6ee7ad3-b54d-4eb4-a8bd-3232f43d3d01.png)

After the patch, no warning is raised and all tests pass.

![tests_no_warnings](https://user-images.githubusercontent.com/1734279/175658929-bf61e4d5-1a72-4e66-b5e4-508ba23ad262.png)

