### PR TITLE
Beanie 2.x support

### DIFF
--- a/fastapi_users_db_beanie/__init__.py
+++ b/fastapi_users_db_beanie/__init__.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 from pymongo import IndexModel
 from pymongo.collation import Collation
 
-__version__ = "4.0.0"
+__version__ = "5.0.0"
 
 
 class BeanieBaseUser(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "fastapi-users >= 10.0.1",
-    "beanie >=1.11.0,<2.0.0",
+    "beanie >=1.20.0,<3.0.0",
 ]
 
 [project.urls]

--- a/tests/test_access_token.py
+++ b/tests/test_access_token.py
@@ -5,7 +5,8 @@ import pymongo.errors
 import pytest
 import pytest_asyncio
 from beanie import Document, PydanticObjectId, init_beanie
-from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
+from pymongo.asynchronous.database import AsyncDatabase
+from pymongo.asynchronous.mongo_client import AsyncMongoClient
 
 from fastapi_users_db_beanie.access_token import (
     BeanieAccessTokenDatabase,
@@ -19,7 +20,7 @@ class AccessToken(BeanieBaseAccessToken, Document):
 
 @pytest_asyncio.fixture
 async def mongodb_client():
-    client = AsyncIOMotorClient(
+    client = AsyncMongoClient(
         "mongodb://localhost:27017",
         serverSelectionTimeoutMS=10000,
         uuidRepresentation="standard",
@@ -28,7 +29,7 @@ async def mongodb_client():
     try:
         await client.server_info()
         yield client
-        client.close()
+        await client.close()
     except pymongo.errors.ServerSelectionTimeoutError:
         pytest.skip("MongoDB not available", allow_module_level=True)
         return
@@ -36,9 +37,9 @@ async def mongodb_client():
 
 @pytest_asyncio.fixture
 async def beanie_access_token_db(
-    mongodb_client: AsyncIOMotorClient,
+    mongodb_client: AsyncMongoClient,
 ) -> AsyncGenerator[BeanieAccessTokenDatabase, None]:
-    database: AsyncIOMotorDatabase = mongodb_client["test_database"]
+    database: AsyncDatabase = mongodb_client["test_database"]
     await init_beanie(database=database, document_models=[AccessToken])
 
     yield BeanieAccessTokenDatabase(AccessToken)

--- a/tests/test_fastapi_users_db_beanie.py
+++ b/tests/test_fastapi_users_db_beanie.py
@@ -6,8 +6,9 @@ import pytest
 import pytest_asyncio
 from beanie import Document, PydanticObjectId, init_beanie
 from fastapi_users import InvalidID
-from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
 from pydantic import Field
+from pymongo.asynchronous.database import AsyncDatabase
+from pymongo.asynchronous.mongo_client import AsyncMongoClient
 
 from fastapi_users_db_beanie import (
     BaseOAuthAccount,
@@ -31,7 +32,7 @@ class UserOAuth(User):
 
 @pytest_asyncio.fixture
 async def mongodb_client():
-    client = AsyncIOMotorClient(
+    client = AsyncMongoClient(
         "mongodb://localhost:27017",
         serverSelectionTimeoutMS=10000,
         uuidRepresentation="standard",
@@ -40,7 +41,7 @@ async def mongodb_client():
     try:
         await client.server_info()
         yield client
-        client.close()
+        await client.close()
     except pymongo.errors.ServerSelectionTimeoutError:
         pytest.skip("MongoDB not available", allow_module_level=True)
         return
@@ -48,9 +49,9 @@ async def mongodb_client():
 
 @pytest_asyncio.fixture
 async def beanie_user_db(
-    mongodb_client: AsyncIOMotorClient,
+    mongodb_client: AsyncMongoClient,
 ) -> AsyncGenerator[BeanieUserDatabase, None]:
-    database: AsyncIOMotorDatabase = mongodb_client["test_database"]
+    database: AsyncDatabase = mongodb_client["test_database"]
     await init_beanie(database=database, document_models=[User])
 
     yield BeanieUserDatabase(User)
@@ -60,9 +61,9 @@ async def beanie_user_db(
 
 @pytest_asyncio.fixture
 async def beanie_user_db_oauth(
-    mongodb_client: AsyncIOMotorClient,
+    mongodb_client: AsyncMongoClient,
 ) -> AsyncGenerator[BeanieUserDatabase, None]:
-    database: AsyncIOMotorDatabase = mongodb_client["test_database"]
+    database: AsyncDatabase = mongodb_client["test_database"]
     await init_beanie(database=database, document_models=[UserOAuth])
 
     yield BeanieUserDatabase(UserOAuth, OAuthAccount)


### PR DESCRIPTION
Related issue: #16.
There already is [a PR for supporting Beanie 2.x](https://github.com/fastapi-users/fastapi-users-db-beanie/pull/17), but I'd argue that it's missing some important details.

First things first – supporting Beanie 2.x is important because the move they made that caused the major version bump is the right one. I am citing the README from the Motor repo:

> As of May 14th, 2025, Motor is deprecated in favor of the GA release of the PyMongo Async API. No new features will be added to Motor, and only bug fixes will be provided until it reaches end of life on May 14th, 2026. After that, only critical bug fixes will be made until final support ends on May 14th, 2027. We strongly recommend migrating to the PyMongo Async API while Motor is still supported. For help transitioning, see the Migrate to PyMongo Async guide: [https://www.mongodb.com/docs/languages/python/pymongo-driver/current/reference/migration/>](https://www.mongodb.com/docs/languages/python/pymongo-driver/current/reference/migration/%3E).

That's what Beanie 2.x does.

The problem with the other PR is that it still uses Motor in the tests (see below) and the version range defined for the `beanie` dependency (`"beanie >=1.11.0,<2.1.0"`) seems to be problematic:

1. `hatch run test` fails for `beanie >=1.11.0, <=1.19.0` (I realized after writing this PR that this has actually nothing to do with the changes made here – this seems to be an issue that's already present, so it's unrelated, but still important!), so Beanie support should start at `1.20.0`. This version didn't contain official stable versions of the asyncronous API yet, but it seems to run just fine.
2. Increasing the upper bound of the supported Beanie version to `< 2.1.0` doesn't seem to make any sense, as breaking changes in versions `> 0.x` should always come with a major version bump and I'd trust the Beanie community to do so. Therefore, setting the dependency to `"beanie >=1.20.0,<3.0.0"` seems to be the way to go. BTW `beanie 1.20.0` is more than two years old right now, so I don't think we're cutting off any significant amounts of projects, here.

As I mentioned above, the test cases are explicitly using modules from the Motor package which will soon be EOL and Beanie stops using it entirely from v`2.x` on.

- stop using Motor
- adjust supported Beanie versions
- bump major version (because the previous step is technically a breaking change)